### PR TITLE
Fix dynamic card layout and spacing issues

### DIFF
--- a/frontend/src/components/Lane.css
+++ b/frontend/src/components/Lane.css
@@ -24,15 +24,10 @@
 }
 
 .card-wrapper {
-  margin-left: -48px; /* 调整负边距以平铺显示更多内容 */
-  z-index: 1;
   position: relative;
-  transition: box-shadow 0.2s, transform 0.18s;
-  overflow: visible;
+  transition: transform 0.2s ease-out, box-shadow 0.2s;
   width: 72px;
-  min-width: 72px; /* 固定宽度防止压缩 */
-  max-width: 72px;
-  height: 110px;
+  height: 100px;
 }
 
 /* 堆叠z-index：后面的牌层级高，弹起牌层级最高 */


### PR DESCRIPTION
This commit addresses user feedback regarding card display in the game lanes. The previous fix was insufficient and has been replaced with a more robust, dynamic solution.

Key changes:

1.  **Dynamic Card Spacing:**
    -   Modified `Lane.jsx` to dynamically calculate the `margin-left` for each card based on the number of cards and the width of the container lane.
    -   The default spacing is now one-third of the card's width, as requested by the user.
    -   If the cards overflow the container, the spacing is reduced to fit all cards within the visible area.

2.  **CSS Refactoring:**
    -   Removed the fixed `margin-left` from `.card-wrapper` in `Lane.css` to allow for the dynamic inline styles to take effect.
    -   The `overflow: hidden` properties on the main game containers have been removed to prevent selected cards from being clipped.

3.  **Removed Inline Styles from Practice Game:**
    -   The inline `<style>` block has been removed from `PracticeThirteenGame.jsx` to ensure all lane and card styles are centralized in `Lane.css` for consistency.