### PR TITLE
feat: Unify game table layout

### DIFF
--- a/frontend/src/components/EightCardGame.css
+++ b/frontend/src/components/EightCardGame.css
@@ -155,17 +155,20 @@
   font-weight: 600;
 }
 
-/* Pre-deal state */
-.pre-deal-content {
-  flex-grow: 1;
+.card-deck-placeholder {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80px;
+  height: 110px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border: 2px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 20px;
-}
-
-.waiting-text {
-  font-size: 1.1rem;
-  opacity: 0.9;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.3);
+  z-index: 0;
 }

--- a/frontend/src/components/EightCardGame.jsx
+++ b/frontend/src/components/EightCardGame.jsx
@@ -135,25 +135,6 @@ const EightCardGame = ({ roomId, gameMode, onBackToLobby, user, onGameEnd }) => 
     </div>
   );
 
-  if (!hasDealt) {
-    return (
-      <div className="game-table-container pre-deal">
-        <div className="game-table-header">
-          <button onClick={onBackToLobby} className="table-action-btn back-btn">&larr; 退出</button>
-          <div className="game-table-title">急速八张 {gameMode === 'special' ? '独头场' : '普通场'}</div>
-        </div>
-        <div className="pre-deal-content">
-          {renderPlayerStatus()}
-          <div className="waiting-text">等待玩家准备...</div>
-          <button className="table-action-btn confirm-btn" onClick={handleReadyToggle} disabled={isLoading}>
-            {isLoading ? '请稍候...' : (isPreparing ? '取消准备' : '点击准备')}
-          </button>
-          {errorMessage && <p className="error-text">{errorMessage}</p>}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="game-table-container">
       <div className="game-table-header">
@@ -162,14 +143,23 @@ const EightCardGame = ({ roomId, gameMode, onBackToLobby, user, onGameEnd }) => 
       </div>
       {renderPlayerStatus()}
       <div className="lanes-container">
+        {!hasDealt && <div className="card-deck-placeholder">牌墩</div>}
         <Lane title="牌" cards={middleLane} onCardClick={() => {}} onLaneClick={() => {}} selectedCards={selectedCards} expectedCount={LANE_LIMITS.middle} />
       </div>
       {errorMessage && <p className="error-text">{errorMessage}</p>}
       <div className="game-table-footer">
-        <button onClick={handleAutoSort} className="table-action-btn sort-btn" disabled={isReady}>自动理牌</button>
-        <button onClick={handleConfirm} disabled={isLoading || isReady} className="table-action-btn confirm-btn">
-          {isReady ? '等待开牌' : (isLoading ? '提交中...' : '确认')}
-        </button>
+        {!hasDealt ? (
+          <button className="table-action-btn confirm-btn" onClick={handleReadyToggle} disabled={isLoading}>
+            {isLoading ? '请稍候...' : (isPreparing ? '取消准备' : '点击准备')}
+          </button>
+        ) : (
+          <>
+            <button onClick={handleAutoSort} className="table-action-btn sort-btn" disabled={isReady}>自动理牌</button>
+            <button onClick={handleConfirm} disabled={isLoading || isReady} className="table-action-btn confirm-btn">
+              {isReady ? '等待开牌' : (isLoading ? '提交中...' : '确认')}
+            </button>
+          </>
+        )}
       </div>
       {gameResult && <GameResultModal result={gameResult} onClose={handleCloseResult} />}
     </div>

--- a/frontend/src/components/ThirteenGame.css
+++ b/frontend/src/components/ThirteenGame.css
@@ -155,17 +155,20 @@
   font-weight: 600;
 }
 
-/* Pre-deal state */
-.pre-deal-content {
-  flex-grow: 1;
+.card-deck-placeholder {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80px;
+  height: 110px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border: 2px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 20px;
-}
-
-.waiting-text {
-  font-size: 1.1rem;
-  opacity: 0.9;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.3);
+  z-index: 0;
 }

--- a/frontend/src/components/ThirteenGame.jsx
+++ b/frontend/src/components/ThirteenGame.jsx
@@ -154,25 +154,6 @@ const ThirteenGame = ({ roomId, gameMode, onBackToLobby, user, onGameEnd }) => {
     </div>
   );
 
-  if (!hasDealt) {
-    return (
-      <div className="game-table-container pre-deal">
-        <div className="game-table-header">
-          <button onClick={onBackToLobby} className="table-action-btn back-btn">&larr; 退出</button>
-          <div className="game-table-title">十三张 {gameMode === 'double' ? '翻倍场' : '普通场'}</div>
-        </div>
-        <div className="pre-deal-content">
-          {renderPlayerStatus()}
-          <div className="waiting-text">等待玩家准备...</div>
-          <button className="table-action-btn confirm-btn" onClick={handleReadyToggle} disabled={isLoading}>
-            {isLoading ? '请稍候...' : (isPreparing ? '取消准备' : '点击准备')}
-          </button>
-          {errorMessage && <p className="error-text">{errorMessage}</p>}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="game-table-container">
       <div className="game-table-header">
@@ -181,16 +162,25 @@ const ThirteenGame = ({ roomId, gameMode, onBackToLobby, user, onGameEnd }) => {
       </div>
       {renderPlayerStatus()}
       <div className="lanes-container">
+        {!hasDealt && <div className="card-deck-placeholder">牌墩</div>}
         <Lane title="头道" cards={topLane} onCardClick={() => {}} onLaneClick={() => {}} selectedCards={selectedCards} expectedCount={LANE_LIMITS.top} />
         <Lane title="中道" cards={middleLane} onCardClick={() => {}} onLaneClick={() => {}} selectedCards={selectedCards} expectedCount={LANE_LIMITS.middle} />
         <Lane title="尾道" cards={bottomLane} onCardClick={() => {}} onLaneClick={() => {}} selectedCards={selectedCards} expectedCount={LANE_LIMITS.bottom} />
       </div>
       {errorMessage && <p className="error-text">{errorMessage}</p>}
       <div className="game-table-footer">
-        <button onClick={handleAutoSort} className="table-action-btn sort-btn" disabled={isReady}>自动理牌</button>
-        <button onClick={handleConfirm} disabled={isLoading || isReady} className="table-action-btn confirm-btn">
-          {isReady ? '等待开牌' : (isLoading ? '提交中...' : '确认')}
-        </button>
+        {!hasDealt ? (
+          <button className="table-action-btn confirm-btn" onClick={handleReadyToggle} disabled={isLoading}>
+            {isLoading ? '请稍候...' : (isPreparing ? '取消准备' : '点击准备')}
+          </button>
+        ) : (
+          <>
+            <button onClick={handleAutoSort} className="table-action-btn sort-btn" disabled={isReady}>自动理牌</button>
+            <button onClick={handleConfirm} disabled={isLoading || isReady} className="table-action-btn confirm-btn">
+              {isReady ? '等待开牌' : (isLoading ? '提交中...' : '确认')}
+            </button>
+          </>
+        )}
       </div>
       {gameResult && <GameResultModal result={gameResult} onClose={handleCloseResult} />}
     </div>


### PR DESCRIPTION
This commit refactors the game table components (`ThirteenGame.jsx` and `EightCardGame.jsx`) to use a single, unified layout.

The following changes were made:
- The conditional rendering for the 'pre-deal' state has been removed.
- The full game table UI is now always visible, providing a more consistent user experience.
- A placeholder element for the card deck has been added to the center of the table.
- The footer buttons are now conditionally rendered based on the game state (`hasDealt`).