### PR TITLE
fix: Correct online player count logic

### DIFF
--- a/backend/api/get_online_count.php
+++ b/backend/api/get_online_count.php
@@ -7,7 +7,7 @@ $result = $conn->query("
     SELECT COUNT(DISTINCT rp.user_id) AS online_count
     FROM room_players rp
     JOIN game_rooms gr ON rp.room_id = gr.id
-    WHERE gr.status IN ('matching', 'playing')
+    WHERE gr.status IN ('matching', 'playing') AND rp.is_auto_managed = 0
 ");
 
 if ($result && $row = $result->fetch_assoc()) {


### PR DESCRIPTION
This commit fixes a bug where the online player count was including AI players.

The SQL query in `get_online_count.php` has been modified to only count real human players by filtering out records where `is_auto_managed = 1`.