### PR TITLE
Style: Adjust game table layout for better mobile usability

### DIFF
--- a/frontend/src/components/Lane.css
+++ b/frontend/src/components/Lane.css
@@ -10,7 +10,7 @@
 .card-placement-box {
   width: 100%;
   box-sizing: border-box;
-  min-height: 180px; /* Final increase */
+  min-height: 220px;
   background: #ffffff;
   border-radius: 14px;
   box-shadow: 0 1px 4px #23243c22;
@@ -42,15 +42,15 @@
 }
 
 .card-wrapper {
-  margin-left: -20px; /* Adjusted margin */
+  margin-left: -30px;
   z-index: 1;
   position: relative;
   transition: box-shadow 0.2s, transform 0.18s;
   overflow: visible;
-  width: 90px;      /* Final width increase */
-  min-width: 80px;
-  max-width: 90px;
-  height: 158px;    /* Final height increase */
+  width: 110px;
+  min-width: 100px;
+  max-width: 110px;
+  height: 193px;
 }
 
 /* 堆叠z-index：后面的牌层级高，弹起牌层级最高 */

--- a/frontend/src/components/ThirteenGame.css
+++ b/frontend/src/components/ThirteenGame.css
@@ -27,7 +27,7 @@
 
 .game-table-header, .game-table-footer {
   flex-shrink: 0;
-  padding: 10px 15px;
+  padding: 5px 10px;
   background: var(--table-header-bg);
   backdrop-filter: blur(10px);
   border-radius: 12px;
@@ -38,7 +38,7 @@
 }
 
 .game-table-header {
-  margin-bottom: 15px;
+  margin-bottom: 10px;
 }
 
 .game-table-footer {
@@ -102,7 +102,7 @@
 .players-status-container {
   display: flex;
   justify-content: space-around;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
   gap: 10px;
 }
 
@@ -110,7 +110,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px;
+  padding: 5px;
   border-radius: 8px;
   background: var(--player-status-bg);
   transition: background-color 0.3s;
@@ -125,8 +125,8 @@
 }
 
 .player-avatar {
-  width: 40px;
-  height: 40px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background-color: var(--primary-color);
   color: white;


### PR DESCRIPTION
This commit adjusts the CSS for the main game table to optimize the layout for smaller screens, based on user feedback.

The key changes are:
- The top header and player status bar have had their padding and margins reduced to take up less vertical space.
- The height of the card lanes (`.card-placement-box`) has been significantly increased.
- The size of the cards (`.card-wrapper`) within the lanes has been increased proportionally to be larger and easier to see and interact with.

These coordinated changes free up more screen real estate for the core game area, improving the overall visual hierarchy and user experience on mobile devices.