### PR TITLE
Style: Create a compact layout to maximize game area

### DIFF
--- a/frontend/src/components/Lane.css
+++ b/frontend/src/components/Lane.css
@@ -10,7 +10,7 @@
 .card-placement-box {
   width: 100%;
   box-sizing: border-box;
-  min-height: 220px;
+  min-height: 240px;
   background: #ffffff;
   border-radius: 14px;
   box-shadow: 0 1px 4px #23243c22;
@@ -42,15 +42,15 @@
 }
 
 .card-wrapper {
-  margin-left: -30px;
+  margin-left: -35px;
   z-index: 1;
   position: relative;
   transition: box-shadow 0.2s, transform 0.18s;
   overflow: visible;
-  width: 110px;
-  min-width: 100px;
-  max-width: 110px;
-  height: 193px;
+  width: 120px;
+  min-width: 110px;
+  max-width: 120px;
+  height: 210px;
 }
 
 /* 堆叠z-index：后面的牌层级高，弹起牌层级最高 */

--- a/frontend/src/components/ThirteenGame.css
+++ b/frontend/src/components/ThirteenGame.css
@@ -21,16 +21,16 @@
   flex-direction: column;
   background: linear-gradient(135deg, var(--table-bg-start), var(--table-bg-end));
   color: var(--text-color);
-  padding: 15px;
+  padding: 0 15px 15px 15px;
   box-sizing: border-box;
 }
 
 .game-table-header, .game-table-footer {
   flex-shrink: 0;
-  padding: 5px 10px;
+  padding: 5px;
   background: var(--table-header-bg);
   backdrop-filter: blur(10px);
-  border-radius: 12px;
+  border-radius: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -38,7 +38,7 @@
 }
 
 .game-table-header {
-  margin-bottom: 10px;
+  margin-bottom: 0;
 }
 
 .game-table-footer {
@@ -102,8 +102,10 @@
 .players-status-container {
   display: flex;
   justify-content: space-around;
-  margin-bottom: 10px;
+  margin-bottom: 0;
   gap: 10px;
+  padding: 5px 0;
+  background: rgba(0,0,0,0.05);
 }
 
 .player-status {
@@ -150,9 +152,9 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  gap: 10px;
+  gap: 5px;
   min-height: 0;
-  padding-top: 20px;
+  padding-top: 5px;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
This commit implements a significant layout change based on user feedback to make the game more usable on mobile screens.

The changes create a 'compact' layout where all top banners are compressed and stuck together to maximize the vertical space available for the card lanes.

- The main container's top padding has been removed.
- Vertical margins between the header, player status bar, and the lanes container have been removed to make them stick together.
- The padding and height of the header and player status elements have been minimized.
- The saved space has been reallocated to the card lanes and the cards themselves, which are now substantially larger for better visibility and easier interaction.