### PR TITLE
Style: Implement zero-gap compact layout

### DIFF
--- a/frontend/src/components/Lane.css
+++ b/frontend/src/components/Lane.css
@@ -10,7 +10,7 @@
 .card-placement-box {
   width: 100%;
   box-sizing: border-box;
-  min-height: 240px;
+  min-height: 255px;
   background: #ffffff;
   border-radius: 14px;
   box-shadow: 0 1px 4px #23243c22;
@@ -50,7 +50,7 @@
   width: 120px;
   min-width: 110px;
   max-width: 120px;
-  height: 210px;
+  height: 225px;
 }
 
 /* 堆叠z-index：后面的牌层级高，弹起牌层级最高 */

--- a/frontend/src/components/ThirteenGame.css
+++ b/frontend/src/components/ThirteenGame.css
@@ -104,7 +104,7 @@
   justify-content: space-around;
   margin-bottom: 0;
   gap: 10px;
-  padding: 5px 0;
+  padding: 2px 0;
   background: rgba(0,0,0,0.05);
 }
 
@@ -152,9 +152,9 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  gap: 5px;
+  gap: 0;
   min-height: 0;
-  padding-top: 5px;
+  padding-top: 0;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
This commit implements a final set of styling changes to maximize the game area, based on user feedback.

All vertical gaps and padding between the header, player status bar, and the main card lanes have been removed. This creates a fully compact 'zero-gap' layout at the top of the screen.

The freed vertical space has been reallocated to the card lanes and the cards themselves, making them even larger and improving usability on mobile devices.