### PR TITLE
Style: Adjust card overlap to prevent overflow

### DIFF
--- a/frontend/src/components/Lane.css
+++ b/frontend/src/components/Lane.css
@@ -42,7 +42,7 @@
 }
 
 .card-wrapper {
-  margin-left: -40px;
+  margin-left: -65px;
   z-index: 1;
   position: relative;
   transition: box-shadow 0.2s, transform 0.18s;
@@ -75,7 +75,7 @@
 
 @media (max-width: 450px) {
   .card-wrapper {
-    width: 80px; min-width: 70px; max-width: 80px; height: 112px; margin-left: -25px;
+    width: 80px; min-width: 70px; max-width: 80px; height: 112px; margin-left: -40px;
   }
   .card-placement-box { min-height: 120px; padding: 0 6px; }
 }


### PR DESCRIPTION
This commit fixes a layout issue where cards in the 8-card game would overflow their container.

The negative `margin-left` on the `.card-wrapper` class has been adjusted to be exactly half of the card's width for both desktop and mobile media queries. This creates a 50% overlap between cards, ensuring they fit within the lane view, especially when many cards are present, as in the 8-card game.