### PR TITLE
Style: Reduce card and lane heights

### DIFF
--- a/frontend/src/components/Lane.css
+++ b/frontend/src/components/Lane.css
@@ -8,9 +8,9 @@
 }
 
 .card-placement-box {
-  --card-width: 130px;
-  --card-height: 250px;
-  --card-overlap-px: 65px;
+  --card-width: 104px;
+  --card-height: 200px;
+  --card-overlap-px: 52px;
   --left-buffer: 20px;
 
   width: 100%;
@@ -65,9 +65,9 @@
 
 @media (max-width: 450px) {
   .card-placement-box {
-    --card-width: 80px;
-    --card-height: 112px;
-    --card-overlap-px: 40px;
+    --card-width: 71px;
+    --card-height: 100px;
+    --card-overlap-px: 35px;
     --left-buffer: 10px;
   }
 }


### PR DESCRIPTION
This commit adjusts the height of the card lanes and the cards themselves to be smaller, per the user's latest request.

- Modified `frontend/src/components/Lane.css`:
  - Reduced the values in the CSS variables for `--card-height`, `--card-width`, and `--card-overlap-px` for both desktop and mobile views to decrease the overall size of the card lanes.