### PR TITLE
fix(logic): Correctly rank A-2-3-4-5 straights

### DIFF
--- a/frontend/src/utils/pokerEvaluator.js
+++ b/frontend/src/utils/pokerEvaluator.js
@@ -151,6 +151,21 @@ export function evaluateHand(cards) {
  * @returns {number} > 0 如果 A > B, < 0 如果 A < B, 0 如果相等
  */
 export function compareHands(handA, handB) {
+  // 如果牌型相同且为顺子，应用特殊规则
+  if (handA.rank === HAND_TYPES.STRAIGHT.rank && handB.rank === HAND_TYPES.STRAIGHT.rank) {
+    const isA_A2345 = JSON.stringify(handA.values) === JSON.stringify([5, 4, 3, 2, 1]);
+    const isB_A2345 = JSON.stringify(handB.values) === JSON.stringify([5, 4, 3, 2, 1]);
+
+    // 根据规则，A2345是第二大顺子
+    const rankA = isA_A2345 ? 13.5 : handA.values[0];
+    const rankB = isB_A2345 ? 13.5 : handB.values[0];
+
+    if (rankA !== rankB) {
+      return rankA - rankB;
+    }
+    return 0; // 两个都是A2345或者10JQKA
+  }
+
   // 首先比较牌型等级
   const rankDifference = handA.rank - handB.rank;
   if (rankDifference !== 0) {

--- a/frontend/src/utils/sssScorer.js
+++ b/frontend/src/utils/sssScorer.js
@@ -188,6 +188,20 @@ function compareArea(a, b, area) {
   const rankB = areaTypeRank(typeB, area);
   if (rankA !== rankB) return rankA - rankB;
 
+  // Special handling for straights according to house rules
+  if (typeA === '顺子' && typeB === '顺子') {
+      const getStraightValue = (cards) => {
+          let vals = [...new Set(cards.map(c => VALUE_ORDER[c.split('_')[0]]))].sort((a, b) => a - b);
+          const isA2345 = JSON.stringify(vals) === JSON.stringify([2,3,4,5,14]);
+          if (isA2345) return 13.5; // Second highest straight
+          return vals[vals.length - 1]; // Highest card
+      };
+      const valA = getStraightValue(a);
+      const valB = getStraightValue(b);
+      if (valA !== valB) return valA - valB;
+      return 0;
+  }
+
   if ( (typeA === '同花顺' && typeB === '同花顺') || (typeA === '同花' && typeB === '同花') ) {
     const suitA = SUIT_ORDER[a[0].split('_')[2]];
     const suitB = SUIT_ORDER[b[0].split('_')[2]];


### PR DESCRIPTION
This commit fixes a critical bug in the hand evaluation logic that caused certain valid hands to be incorrectly identified as "fouls" (倒水).

The bug was caused by an incorrect ranking of A-2-3-4-5 straights. The user has specified a house rule where A-2-3-4-5 is the second-highest straight, ranking just below 10-J-Q-K-A. The previous logic treated it as the lowest possible straight.

This change has been implemented in two places to ensure consistency:
1.  In `pokerEvaluator.js`, the `compareHands` function has been updated to handle this special ranking when comparing two straights.
2.  In `sssScorer.js`, the `compareArea` function has been similarly updated to use the same logic, which is crucial for the `isFoul` check.

This fix ensures that the game's hand evaluation and comparison now correctly reflect the intended house rules.