### PR TITLE
debug: Add logging to Telegram webhook

### DIFF
--- a/backend/api/tg_webhook.php
+++ b/backend/api/tg_webhook.php
@@ -1,4 +1,10 @@
 <?php
+// --- Logging for Debugging ---
+$raw_post_data = file_get_contents('php://input');
+$log_file = __DIR__ . '/tg_webhook.log';
+file_put_contents($log_file, $raw_post_data . "\n---\n", FILE_APPEND);
+// --- End Logging ---
+
 require_once 'db_connect.php';
 require_once __DIR__ . '/../config.php';
 


### PR DESCRIPTION
This commit adds temporary logging to the `tg_webhook.php` file to diagnose an issue where the bot is not responding. This code writes the raw POST data from Telegram to a log file.

This is a temporary commit for debugging purposes and will be reverted.