### PR TITLE
feat: Conditionally add AI players in trial mode

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
-    <script type="module" crossorigin src="/assets/index-bZ5fdIwo.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BcMjF_KQ.css">
+    <script type="module" crossorigin src="/assets/index-OFA58dbv.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-_oIzmDUh.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/EightCardGame.jsx
+++ b/frontend/src/components/EightCardGame.jsx
@@ -3,7 +3,7 @@ import { useCardArrangement } from '../hooks/useCardArrangement';
 import { dealOfflineEightCardGame, getSmartSortedHandForEight, calculateEightCardTrialResult, parseCard } from '../utils';
 import GameTable from './GameTable';
 
-const EightCardGame = ({ onBackToLobby, user }) => {
+const EightCardGame = ({ onBackToLobby, user, isTrialMode }) => {
   const {
     topLane,
     middleLane,
@@ -24,9 +24,14 @@ const EightCardGame = ({ onBackToLobby, user }) => {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const aiPlayerInfo = Array(5).fill(0).map((_, i) => ({ id: `ai_${i}`, phone: `AI ${i+1}`, is_ready: false }));
-    setPlayers([{ id: user.id, phone: user.phone, is_ready: false }, ...aiPlayerInfo]);
-  }, [user]);
+    const initialPlayers = [{ id: user.id, phone: user.phone, is_ready: false }];
+    if (isTrialMode) {
+      const aiPlayerInfo = Array(5).fill(0).map((_, i) => ({ id: `ai_${i}`, phone: `AI ${i+1}`, is_ready: false }));
+      setPlayers([...initialPlayers, ...aiPlayerInfo]);
+    } else {
+      setPlayers(initialPlayers);
+    }
+  }, [user, isTrialMode]);
 
   const handleReady = useCallback(() => {
     try {

--- a/frontend/src/components/ThirteenGame.jsx
+++ b/frontend/src/components/ThirteenGame.jsx
@@ -3,7 +3,7 @@ import { useCardArrangement } from '../hooks/useCardArrangement';
 import { dealOfflineThirteenGame, getAiThirteenHand, calculateThirteenTrialResult, getSmartSortedHand, parseCard, isFoul } from '../utils';
 import GameTable from './GameTable';
 
-const ThirteenGame = ({ onBackToLobby, user }) => {
+const ThirteenGame = ({ onBackToLobby, user, isTrialMode }) => {
   const {
     topLane,
     middleLane,
@@ -25,9 +25,14 @@ const ThirteenGame = ({ onBackToLobby, user }) => {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const aiPlayerInfo = Array(3).fill(0).map((_, i) => ({ id: `ai_${i}`, phone: `AI ${i+1}`, is_ready: false }));
-    setPlayers([{ id: user.id, phone: user.phone, is_ready: false }, ...aiPlayerInfo]);
-  }, [user]);
+    const initialPlayers = [{ id: user.id, phone: user.phone, is_ready: false }];
+    if (isTrialMode) {
+      const aiPlayerInfo = Array(3).fill(0).map((_, i) => ({ id: `ai_${i}`, phone: `AI ${i+1}`, is_ready: false }));
+      setPlayers([...initialPlayers, ...aiPlayerInfo]);
+    } else {
+      setPlayers(initialPlayers);
+    }
+  }, [user, isTrialMode]);
 
   // Effect to sort AI hands sequentially in the background after dealing
   useEffect(() => {


### PR DESCRIPTION
Modified `ThirteenGame.jsx` and `EightCardGame.jsx` to only add AI players when the `isTrialMode` prop is true.

This ensures that AI players are only present in trial mode games and not in other online game modes, as per the user's request. The components now accept the `isTrialMode` prop and use it to conditionally populate the game with AI opponents.