### PR TITLE
refactor: Remove AI player filling logic

### DIFF
--- a/backend/api/index.php
+++ b/backend/api/index.php
@@ -59,9 +59,9 @@ switch ($action) {
                 $stmt->execute();
                 $currentPlayers = $stmt->get_result()->fetch_assoc()['current_players'];
                 $stmt->close();
-                if ($currentPlayers < $room['players_count']) {
-                    fillWithAI($conn, $roomId, $room['game_type'], $room['players_count']);
-                }
+                // if ($currentPlayers < $room['players_count']) {
+                //     fillWithAI($conn, $roomId, $room['game_type'], $room['players_count']);
+                // }
                 $stmt = $conn->prepare("SELECT COUNT(*) as ready_players FROM room_players WHERE room_id = ? AND is_ready = 1");
                 $stmt->bind_param("i", $roomId);
                 $stmt->execute();
@@ -304,7 +304,7 @@ switch ($action) {
                 $stmt->bind_param("ii", $roomId, $guestUserId);
                 $stmt->execute();
                 $stmt->close();
-                fillWithAI($conn, $roomId, $gameType, $playersNeeded);
+                // fillWithAI($conn, $roomId, $gameType, $playersNeeded);
                 dealCards($conn, $roomId, $gameType, $playersNeeded);
                 $conn->commit();
                 http_response_code(200);

--- a/backend/utils/utils.php
+++ b/backend/utils/utils.php
@@ -50,43 +50,4 @@ function dealCards($conn, $roomId, $gameType, $playerCount) {
     $stmt->close();
 }
 
-function fillWithAI($conn, $roomId, $gameType, $playersNeeded) {
-    $stmt = $conn->prepare("SELECT COUNT(*) as current_players FROM room_players WHERE room_id=?");
-    $stmt->bind_param("i", $roomId);
-    $stmt->execute();
-    $currentPlayers = $stmt->get_result()->fetch_assoc()['current_players'];
-    $stmt->close();
-
-    $aiToCreate = $playersNeeded - $currentPlayers;
-    if ($aiToCreate <= 0) return;
-
-    for ($i = 1; $i <= $aiToCreate; $i++) {
-        $aiPhone = "ai_player_" . $i;
-        $aiId = null;
-
-        $stmt = $conn->prepare("SELECT id FROM users WHERE phone = ?");
-        $stmt->bind_param("s", $aiPhone);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        if ($row = $result->fetch_assoc()) {
-            $aiId = $row['id'];
-        }
-        $stmt->close();
-
-        if (!$aiId) {
-            $insertStmt = $conn->prepare("INSERT INTO users (phone, password, points) VALUES (?, '', 1000)");
-            $insertStmt->bind_param("s", $aiPhone);
-            $insertStmt->execute();
-            $aiId = $insertStmt->insert_id;
-            $insertStmt->close();
-        }
-
-        if ($aiId) {
-            $stmt = $conn->prepare("INSERT INTO room_players (room_id, user_id, is_ready, is_auto_managed) VALUES (?, ?, 1, 1)");
-            $stmt->bind_param("ii", $roomId, $aiId);
-            $stmt->execute();
-            $stmt->close();
-        }
-    }
-}
 ?>


### PR DESCRIPTION
Removes the feature that automatically adds AI players to game rooms when they are not full.

- The `fillWithAI` function has been removed from `backend/utils/utils.php`.
- The calls to this function in `backend/api/index.php` have been commented out.

This change was requested by the user. It could not be fully tested due to the lack of a PHP execution environment.