### PR TITLE
fix: Correct variable name in onReady handler

### DIFF
--- a/frontend/src/components/ThirteenGame.jsx
+++ b/frontend/src/components/ThirteenGame.jsx
@@ -210,7 +210,7 @@ const ThirteenGame = ({ onBackToLobby, user, roomId, gameMode }) => {
       isReady={isReady}
 
       onBackToLobby={onBackToLobby}
-      onReady={() => handleReady(_isReady)}
+      onReady={() => handleReady(isReady)}
       onConfirm={() => handleConfirm()}
       onAutoSort={handleAutoSort}
       onCardClick={handleCardClick}


### PR DESCRIPTION
This commit fixes a runtime ReferenceError that occurred when clicking the 'Ready' button. The `onReady` prop passed to the `GameTable` component was calling `handleReady` with an undefined variable `_isReady`.

This has been corrected to use the proper `isReady` variable, which is defined in the component's scope.