### PR TITLE
fix: Correctly parse gameMode before API call

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,10 +72,11 @@ function App() {
 
     if (!gameType || matchingStatus[gameType]) return;
 
-    let playerCount = gameType === 'thirteen' ? 4 : null; // Default classic thirteen to 4 players
+    let playerCount = 4; // Default player count
     let finalGameMode = gameMode;
 
-    if (gameType === 'eight') {
+    // If the gameMode string contains player count info (e.g., "4-normal"), parse it.
+    if (gameMode.includes('-')) {
       const parts = gameMode.split('-');
       playerCount = parseInt(parts[0], 10);
       finalGameMode = parts[1];


### PR DESCRIPTION
This commit fixes a 500 Internal Server Error caused by sending a malformed `gameMode` parameter to the backend.

The `handleSelectMode` function in `App.jsx` was only parsing the player count from the game mode string (e.g., "4-normal") for one of the two game types. This has been corrected to a generic check that parses any game mode containing a hyphen.

This ensures that the backend always receives a clean `gameMode` (e.g., "normal") and a separate `playerCount`, preventing the server error.