### PR TITLE
fix: Resolve TypeError in setInitialLanes

### DIFF
--- a/frontend/src/components/ThirteenGame.jsx
+++ b/frontend/src/components/ThirteenGame.jsx
@@ -34,7 +34,7 @@ const ThirteenGame = ({ onBackToLobby, user, roomId, gameMode }) => {
         setPlayers(data.players);
         setPlayerState(data.gameStatus);
         if (data.gameStatus === 'playing' && data.hand) {
-          setInitialLanes(data.hand.top, data.hand.middle, data.hand.bottom);
+          setInitialLanes(data.hand);
         }
         if (data.gameStatus === 'finished' && data.result) {
           setGameResult(data.result);


### PR DESCRIPTION
This commit fixes a TypeError: Cannot read properties of undefined (reading 'map') that occurred in the `fetchGameStatus` function.

The `setInitialLanes` function was being called with an incorrect number of arguments. It expects a single object with `top`, `middle`, and `bottom` properties, but was being called with three separate arguments.

This has been corrected by passing the single `data.hand` object to the function, resolving the runtime error.