### PR TITLE
fix: Display correct max players in game title

### DIFF
--- a/frontend/src/components/ThirteenGame.jsx
+++ b/frontend/src/components/ThirteenGame.jsx
@@ -4,7 +4,7 @@ import { getSmartSortedHand } from '../utils/autoSorter.js';
 import GameTable from './GameTable';
 
 // The component now only accepts props relevant for an online game
-const ThirteenGame = ({ onBackToLobby, user, roomId, gameMode }) => {
+const ThirteenGame = ({ onBackToLobby, user, roomId, gameMode, playerCount }) => {
   const {
     topLane,
     middleLane,
@@ -176,7 +176,7 @@ const ThirteenGame = ({ onBackToLobby, user, roomId, gameMode }) => {
   return (
     <GameTable
       gameType="thirteen"
-      title={`玩家: ${players.length} / 8`}
+      title={`玩家: ${players.length} / ${playerCount || 4}`}
       players={players}
       user={user}
       topLane={topLane}


### PR DESCRIPTION
This commit fixes a UI bug where the game table title would always show a maximum of 8 players, even for 4-player games.

The `ThirteenGame.jsx` component has been modified to accept a `playerCount` prop and use it to dynamically construct the title string, ensuring the correct maximum number of players is displayed.