### PR TITLE
feat: Add 5-point game mode

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
   const [user, setUser] = useState(null);
   const [gameState, setGameState] = useState({ gameType: null, gameMode: null, roomId: null, error: null, gameUser: null });
   const [currentView, setCurrentView] = useState('lobby');
-  const [matchingStatus, setMatchingStatus] = useState({ thirteen: false });
+  const [matchingStatus, setMatchingStatus] = useState({ thirteen: false, 'thirteen-5': false });
   const [updateInfo, setUpdateInfo] = useState({ show: false, version: '', notes: [], url: '' });
   const [showTransfer, setShowTransfer] = useState(false);
   const [viewingGame, setViewingGame] = useState(null); // null, 'thirteen', or 'eight'
@@ -66,7 +66,7 @@ function App() {
     localStorage.removeItem('activeGame');
     setUser(null);
     setGameState({ gameType: null, gameMode: null, roomId: null, error: null, gameUser: null });
-    setMatchingStatus({ thirteen: false });
+    setMatchingStatus({ thirteen: false, 'thirteen-5': false });
     setViewingGame(null);
   };
 
@@ -147,7 +147,7 @@ function App() {
     localStorage.removeItem('activeGame');
     setGameState({ gameType: null, gameMode: null, roomId: null, error: null, gameUser: null });
     setCurrentView('lobby');
-    setMatchingStatus({ thirteen: false });
+    setMatchingStatus({ thirteen: false, 'thirteen-5': false });
     setViewingGame(null);
   };
 

--- a/frontend/src/components/GameLobby.jsx
+++ b/frontend/src/components/GameLobby.jsx
@@ -35,8 +35,6 @@ const GameLobby = ({ onSelectGameType, matchingStatus, user, onProfile, onLogout
     }
   }, [user]);
 
-  const isMatching = matchingStatus.thirteen;
-
   return (
     <div className="lobby-container">
       <header className="lobby-header">
@@ -60,8 +58,8 @@ const GameLobby = ({ onSelectGameType, matchingStatus, user, onProfile, onLogout
       <main className="game-card-grid">
         {/* 2分场 */}
         <div
-          className={`game-card thirteen-bg ${isMatching ? 'disabled' : ''}`}
-          onClick={() => !isMatching && onSelectGameType('thirteen')}
+          className={`game-card thirteen-bg ${matchingStatus.thirteen ? 'disabled' : ''}`}
+          onClick={() => !matchingStatus.thirteen && onSelectGameType('thirteen')}
         >
           <div className="game-card-overlay">
             <div className="game-content">
@@ -69,6 +67,20 @@ const GameLobby = ({ onSelectGameType, matchingStatus, user, onProfile, onLogout
               <p className="game-description">经典模式对局</p>
             </div>
             {matchingStatus.thirteen && <div className="matching-indicator">匹配中...</div>}
+          </div>
+        </div>
+
+        {/* 5分场 */}
+        <div
+          className={`game-card thirteen-bg ${matchingStatus['thirteen-5'] ? 'disabled' : ''}`}
+          onClick={() => !matchingStatus['thirteen-5'] && onSelectGameType('thirteen-5')}
+        >
+          <div className="game-card-overlay">
+            <div className="game-content">
+              <h2 className="game-title">5分场</h2>
+              <p className="game-description">高手进阶对局</p>
+            </div>
+            {matchingStatus['thirteen-5'] && <div className="matching-indicator">匹配中...</div>}
           </div>
         </div>
       </main>

--- a/frontend/src/components/GameModeSelection.jsx
+++ b/frontend/src/components/GameModeSelection.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import './GameModeSelection.css';
 
 const GameModeSelection = ({ gameType, onSelectMode, onBack }) => {
-  const gameTitle = gameType === 'thirteen' ? '2分场' : '5分场';
+  const gameTitles = {
+    'thirteen': '2分场',
+    'thirteen-5': '5分场',
+  };
+  const gameTitle = gameTitles[gameType] || '游戏'; // Fallback to '游戏'
 
   const sharedModes = [
     { key: '4-normal', title: '4人普通场', desc: '标准4人对局' },


### PR DESCRIPTION
This commit introduces a new "5分场" (5-point field) game mode, which is a duplicate of the existing "2分场" but with a higher point multiplier.

- Frontend:
  - Added a new card to the game lobby for the 5-point mode.
  - Updated state management in `App.jsx` to handle the new `thirteen-5` game type.
  - Refactored `GameModeSelection.jsx` to make the game title display more robust.
- Backend:
  - Implemented a point multiplier system in `backend/api/index.php`.
  - The multiplier is determined by the `game_type` of the room (2 for 'thirteen', 5 for 'thirteen-5').
  - The final score is now multiplied by the appropriate factor before being saved to the database.