### PR TITLE
feat: Add 5-point game mode and fix card dealing logic

### DIFF
--- a/frontend/src/components/ThirteenGame.jsx
+++ b/frontend/src/components/ThirteenGame.jsx
@@ -169,6 +169,11 @@ const ThirteenGame = ({ onBackToLobby, user, roomId, gameMode, playerCount }) =>
       if (!data.success) {
         throw new Error(data.message || `Failed to ${action}.`);
       }
+      // If the 'ready' action caused cards to be dealt, the hand will be in the response.
+      if (data.cardsDealt && data.hand) {
+        setInitialLanes(data.hand);
+      }
+      // We still call this to get the latest state for all players
       fetchGameStatus();
     } catch (error) {
       setErrorMessage(error.message);


### PR DESCRIPTION
This commit introduces two main changes:
1. A new "5分场" (5-point field) game mode.
2. A fix for a bug where cards were not dealt after all players were ready.

**New Feature: 5-Point Game Mode**
- **Frontend**:
  - Added a new card to the game lobby for the 5-point mode (`thirteen-5`).
  - Updated application state to handle matching for the new game type.
  - Refactored the game mode selection screen for robustness.
- **Backend**:
  - Implemented a point multiplier system based on the `game_type`. The "2分场" (`thirteen`) has a 2x multiplier, and the new "5分场" (`thirteen-5`) has a 5x multiplier.

**Bug Fix: Cards Not Dealt**
- The root cause was a combination of a frontend polling issue and a suboptimal backend response.
- **Backend**: The `player_action` for `ready` has been refactored. If the ready action triggers a deal, the backend now immediately returns the player's hand in the response.
- **Frontend**: The `handleReady` function has been updated to handle the new, direct response from the backend. It now renders the hand immediately, improving responsiveness and avoiding the previous error state.