### PR TITLE
Fix: Add last_active column to users table to fix 502 error

### DIFF
--- a/setup_db.sql
+++ b/setup_db.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `phone` varchar(255) NOT NULL,
   `password` varchar(255) NOT NULL,
   `points` int(11) NOT NULL DEFAULT 1000,
+  `last_active` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `phone` (`phone`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
The API endpoint `/api/index.php?action=get_online_count` was returning a 502 Bad Gateway error. This was caused by a fatal `mysqli_sql_exception` in the PHP backend.

The exception was thrown because the SQL query in `get_online_count.php` was referencing a non-existent column `last_active` in the `users` table.

This commit fixes the issue by adding the `last_active` column to the `users` table in the database schema defined in `setup_db.sql`.