### PR TITLE
Fix: Add migration script for database schema update

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,21 @@
+-- This script updates the database schema to support multi-round games.
+-- Please back up your database before running this script.
+
+-- Add 'current_round' column to 'game_rooms' table
+-- This command may fail if the column already exists. This is expected.
+ALTER TABLE game_rooms ADD COLUMN current_round INT(11) NOT NULL DEFAULT 0;
+
+-- Add 'total_rounds' column to 'game_rooms' table
+-- This command may fail if the column already exists. This is expected.
+ALTER TABLE game_rooms ADD COLUMN total_rounds INT(11) NOT NULL DEFAULT 1;
+
+-- Create 'game_rounds' table
+CREATE TABLE IF NOT EXISTS `game_rounds` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `room_id` int(11) NOT NULL,
+  `round_number` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `hand` text,
+  PRIMARY KEY (`id`),
+  KEY `room_round_user_idx` (`room_id`,`round_number`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
This commit adds a `migration.sql` file to help users update their database schema to support the new multi-round game logic.

This script will:
- Add the `current_round` and `total_rounds` columns to the `game_rooms` table.
- Create the new `game_rounds` table.

This is in response to the user's report of a database error after the previous update.