### PR TITLE
Fix: Correct SQL query in match API

### DIFF
--- a/backend/api/actions/match.php
+++ b/backend/api/actions/match.php
@@ -50,7 +50,7 @@ try {
         $stmt->close();
     } else { // 'join' or default 'match' action
         // Find an available room
-        $stmt = $conn->prepare("SELECT r.id, COUNT(rp.user_id) as player_count FROM game_rooms r LEFT JOIN room_players rp ON r.id = rp.room_id WHERE r.game_type = ? AND r.status IN ('waiting', 'finished') GROUP BY r.id HAVING player_count < r.player_count ORDER BY r.created_at ASC LIMIT 1");
+        $stmt = $conn->prepare("SELECT r.id, r.player_count FROM game_rooms r LEFT JOIN room_players rp ON r.id = rp.room_id WHERE r.game_type = ? AND r.status IN ('waiting', 'finished') GROUP BY r.id, r.player_count HAVING COUNT(rp.user_id) < r.player_count ORDER BY r.created_at ASC LIMIT 1");
         $stmt->bind_param("s", $gameType);
         $stmt->execute();
         $result = $stmt->get_result();


### PR DESCRIPTION
This commit fixes a 500 internal server error that was occurring when a user tried to join a game. The error was caused by an incorrect SQL query in the `match.php` script.

The `SELECT` query for finding an available room had an error in the `HAVING` clause, which was trying to reference a column that was not available in that context. This caused the database operation to fail and the server to return a 500 error.

The query has been corrected to properly compare the current number of players in a room with the room's capacity. This resolves the 500 error and allows players to join rooms successfully.