### PR TITLE
Fix API routing by using a relative path

### DIFF
--- a/backend/api/index.php
+++ b/backend/api/index.php
@@ -7,7 +7,7 @@ error_log("--- backend/api/index.php execution started ---");
 header("Content-Type: application/json; charset=UTF-8");
 
 // --- Directory and Action Sanity Checks ---
-$actionsDir = dirname(__FILE__) . '/actions';
+$actionsDir = 'actions';
 if (!is_dir($actionsDir)) {
     http_response_code(500);
     $errorMessage = 'Internal Server Error: Actions directory not found.';


### PR DESCRIPTION
This commit attempts to fix a persistent "Unknown API action provided" error by changing the way file paths are constructed in the API router (`backend/api/index.php`).

The change replaces the absolute path construction using `dirname(__FILE__)` with a simple relative path for the `actions` directory. This is a speculative fix for a potential server environment issue where `file_exists` might be failing due to path resolution problems.

This is the latest in a series of attempts to debug this issue without access to server logs or a reproducible local environment.