### PR TITLE
Fix database error by generating a unique room_code

### DIFF
--- a/backend/api/actions/match.php
+++ b/backend/api/actions/match.php
@@ -38,8 +38,9 @@ try {
 
     if ($matchAction === 'create') {
         // Always create a new room
-        $stmt = $conn->prepare("INSERT INTO game_rooms (game_type, status, player_count) VALUES (?, 'waiting', ?)");
-        $stmt->bind_param("si", $gameType, $playerCount);
+        $roomCode = generate_room_code();
+        $stmt = $conn->prepare("INSERT INTO game_rooms (game_type, status, player_count, room_code) VALUES (?, 'waiting', ?, ?)");
+        $stmt->bind_param("sis", $gameType, $playerCount, $roomCode);
         $stmt->execute();
         $roomId = $stmt->insert_id;
         $stmt->close();

--- a/backend/utils/utils.php
+++ b/backend/utils/utils.php
@@ -172,4 +172,14 @@ function submitPlayerHand($conn, $userId, $roomId, $hand) {
 }
 
 require_once __DIR__ . '/scorer.php';
+
+function generate_room_code($length = 6) {
+    $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    $charactersLength = strlen($characters);
+    $randomString = '';
+    for ($i = 0; $i < $length; $i++) {
+        $randomString .= $characters[rand(0, $charactersLength - 1)];
+    }
+    return $randomString;
+}
 ?>


### PR DESCRIPTION
This commit fixes a "Duplicate entry" database error that occurred when creating a new game room.

The error was caused by the `match.php` script not generating a unique `room_code` for new rooms. This resulted in the database using a default empty string, which violated the `UNIQUE` constraint on the `room_code` column.

The fix involves two parts:
1.  A new function `generate_room_code` has been added to `backend/utils/utils.php` to create a random, unique code.
2.  The `match.php` script has been updated to call this function and insert the generated `room_code` into the `game_rooms` table when a new room is created.