### PR TITLE
Workaround for 'Unknown API action' error for 'pa' action

### DIFF
--- a/backend/api/index.php
+++ b/backend/api/index.php
@@ -26,6 +26,13 @@ if (!is_readable($actionsDir)) {
 
 // --- Action Processing ---
 $action = $_REQUEST['action'] ?? '';
+
+// This is a temporary hack to bypass the file_exists issue for the 'pa' action.
+if ($action === 'pa') {
+    require_once __DIR__ . '/actions/pa.php';
+    exit;
+}
+
 $action = explode(':', $action)[0];
 error_log("Full request: " . print_r($_REQUEST, true));
 


### PR DESCRIPTION
This commit implements a workaround for the persistent "Unknown API action provided" error affecting the `pa` (formerly `player_action`) endpoint.

After numerous attempts to diagnose the root cause of `file_exists()` failing for this specific action, this change bypasses the dynamic routing logic in `backend/api/index.php` for the `pa` action and includes the action file directly.

This is a targeted hack to restore functionality to this endpoint, as the underlying environment issue causing the routing to fail could not be determined.