### PR TITLE
Refactor API actions to standardize database connections

### DIFF
--- a/backend/api/actions/find_user.php
+++ b/backend/api/actions/find_user.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $data = json_decode(file_get_contents("php://input"));
 $phone = $data->phone ?? '';
 if (empty($phone)) {

--- a/backend/api/actions/game_status.php
+++ b/backend/api/actions/game_status.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $roomId = (int)($_GET['roomId'] ?? 0);
 $userId = (int)($_GET['userId'] ?? 0);
 

--- a/backend/api/actions/get_online_count.php
+++ b/backend/api/actions/get_online_count.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $onlineCount = 0;
 $query = "
     SELECT COUNT(DISTINCT id) as onlineCount

--- a/backend/api/actions/leave_room.php
+++ b/backend/api/actions/leave_room.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $input = json_decode(file_get_contents('php://input'), true);
 $userId = (int)($input['userId'] ?? 0);
 $roomId = (int)($input['roomId'] ?? 0);

--- a/backend/api/actions/login.php
+++ b/backend/api/actions/login.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $data = json_decode(file_get_contents("php://input"));
 if (!isset($data->phone) || !isset($data->password)) {
     http_response_code(400);

--- a/backend/api/actions/register.php
+++ b/backend/api/actions/register.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $data = json_decode(file_get_contents("php://input"));
 if (!isset($data->phone) || !isset($data->password)) {
     http_response_code(400);

--- a/backend/api/actions/save_scores.php
+++ b/backend/api/actions/save_scores.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $input = json_decode(file_get_contents('php://input'), true);
 $roomId = (int)($input['roomId'] ?? 0);
 $scores = $input['scores'] ?? [];

--- a/backend/api/actions/transfer_points.php
+++ b/backend/api/actions/transfer_points.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $data = json_decode(file_get_contents("php://input"));
 $fromId = (int)($data->fromId ?? 0);
 $toId = (int)($data->toId ?? 0);

--- a/backend/api/actions/update_activity.php
+++ b/backend/api/actions/update_activity.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../../utils/utils.php';
 
+$conn = db_connect();
+
 $input = json_decode(file_get_contents('php://input'), true);
 $userId = (int)($input['userId'] ?? 0);
 if ($userId > 0) {


### PR DESCRIPTION
This commit refactors the API action files in `backend/api/actions/` to ensure a consistent method for handling database connections.

Previously, some files relied on a global `$conn` variable while others created a new connection explicitly. This has been standardized so that all action files now call the `db_connect()` function to get a database connection.

This improves the consistency, robustness, and maintainability of the backend code.