### PR TITLE
feat: Add 'prepare' as an alias for 'ready' action

### DIFF
--- a/backend/api/actions/player_action.php
+++ b/backend/api/actions/player_action.php
@@ -26,6 +26,7 @@ $conn->begin_transaction();
 
 try {
     switch ($action) {
+        case 'prepare':
         case 'ready':
             $stmt = $conn->prepare("UPDATE room_players SET is_ready = 1 WHERE user_id = ? AND room_id = ?");
             $stmt->bind_param("ii", $userId, $roomId);


### PR DESCRIPTION
This change adds a 'prepare' case to the `player_action.php` file, which falls through to the existing 'ready' case. This ensures backward compatibility with older clients that may still be sending the 'prepare' action.

This change is made to address an "Unknown API action provided" error that was reported by a user.