### PR TITLE
Fix backend routing for POST requests

### DIFF
--- a/backend/api/index.php
+++ b/backend/api/index.php
@@ -25,7 +25,7 @@ if (!is_readable($actionsDir)) {
 }
 
 // --- Action Processing ---
-$action = $_REQUEST['action'] ?? '';
+$action = $_GET['action'] ?? '';
 $action = explode(':', $action)[0];
 error_log("Full request: " . print_r($_REQUEST, true));
 


### PR DESCRIPTION
The backend router in `api/index.php` was using `$_REQUEST['action']` to determine which action file to load. When the frontend sends a POST request to `?action=player_action` with an `action` parameter in the POST body (e.g., `action=submit_hand`), the `$_POST['action']` would overwrite the `$_GET['action']` in the `$_REQUEST` superglobal.

This caused the router to look for a non-existent file (e.g., `actions/submit_hand.php`) instead of `actions/player_action.php`, resulting in a 404 Not Found error.

The fix is to change the router to use `$_GET['action']` explicitly, ensuring that it always uses the action from the URL query string for routing.